### PR TITLE
Cache pip dependencies on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 python:
   - 3.6.3
 env:


### PR DESCRIPTION
This will help speed up builds by reducing the time spent downloading dependencies