### PR TITLE
Add camera support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,26 @@ coverage run -m unittest                        # Run tests with coverage
 coverage report -m --skip-covered --include=./* # Report files without 100% coverage
 ```
 
+## Dev Log
+
+<img align="right" alt="Pickle hops around an early rendition of the game's castle" src="https://user-images.githubusercontent.com/2885412/91630544-090e2480-e987-11ea-9b2a-a36d9f2b32a7.gif" width="30%">
+<p align="right" width="60%"><strong>Aug 2020</strong><br>The camera was implemented, allowing Pickle to explore maps created with the Tiled editor.</p>
+<p> </p>
+<img align="left" alt="Pickle stands in a castle entry hall" src="https://user-images.githubusercontent.com/2885412/48993397-45498c80-f0f2-11e8-929c-47a70d75289b.gif" width="30%">
+<p align="left" width="60%"><strong>Nov 2018</strong><br>Support for the Tiled editor was added, and the demo now showcased a simple castle interior.</p>
+<p> </p>
+<img align="right" alt="A dog jumps and faces the direction she moves in" src="https://user-images.githubusercontent.com/2885412/48958746-0f4fb100-ef16-11e8-9b6c-a8971ecec046.gif" width="30%">
+<p align="right" width="60%"><strong>Nov 2018</strong><br>Tiles could now be animated, and Pickle's original artwork was drawn.</p>
+<p> </p>
+<img align="left" alt="A green tile moves and jumps against other tiles" src="https://user-images.githubusercontent.com/2885412/48684936-deaff600-eb68-11e8-9ef8-733bdb9f52fc.gif" width="30%">
+<p align="left" width="60%"><strong>Nov 2018</strong><br>Player input was now supported, and the demo updated to allow horizontal movement and jumping.</p>
+<p> </p>
+<img align="right" alt="Green tiles of varying gravity colliding" src="https://user-images.githubusercontent.com/2885412/38073387-9ed01476-32df-11e8-8f27-04f75f8de919.gif" width="30%">
+<p align="right" width="60%"><strong>Mar 2018</strong><br>Collision resolution was implemented, allowing physical objects to rest against one another.</p>
+<p> </p>
+<img align="left" alt="A green tile falling against a black background" src="https://user-images.githubusercontent.com/2885412/33042770-e1e62a9a-cdf7-11e7-9cdf-7e236ba7aa53.gif" width="30%">
+<p align="left" width="60%"><strong>Nov 2017</strong><br>The initial physics engine was added, setting up for collision detection.</p>
+
 [coverage-badge]: https://codecov.io/gh/codehearts/pickles-fetch-quest/branch/master/graph/badge.svg
 [coverage-link]:  https://codecov.io/gh/codehearts/pickles-fetch-quest
 [health-badge]:   https://api.codeclimate.com/v1/badges/d43c91516157f1c02dd0/maintainability

--- a/engine/camera/__init__.py
+++ b/engine/camera/__init__.py
@@ -1,0 +1,3 @@
+from .camera import Camera
+
+__all__ = ['Camera']

--- a/engine/camera/camera.py
+++ b/engine/camera/camera.py
@@ -1,0 +1,98 @@
+from pyglet import gl
+
+
+class Camera(object):
+    """Camera for controlling zoom and tracking game objects.
+
+    Attributes:
+        x (int): The x coordinate of the camera's lower left corner.
+        y (int): The y coordinate of the camera's lower left corner.
+    """
+
+    def __init__(self, width, height):
+        """Creates a new camera with the given dimensions.
+
+        Args:
+            width (int): The width of the camera.
+            height (int): The height of the camera.
+        """
+        self._width = width
+        self._height = height
+
+        self._x = 0
+        self._y = 0
+
+        # Offset for the camera to be centered
+        self._x_offset = width // 2
+        self._y_offset = height // 2
+
+        # Camera has no boundaries by default
+        self._x_boundary = None
+        self._y_boundary = None
+
+    def set_boundary(self, width, height):
+        """Sets a boundary for the camera's movement.
+
+        The camera will be locked within (0, 0) and (width, height).
+        Setting either axis' boundary to None will unlock that axis.
+
+        Args:
+            width (int): The x coordinate for the right edge of the boundary.
+            height (int): The y coordinate for the upper edge of the boundary.
+        """
+        self._x_boundary = width - self._width
+        self._y_boundary = height - self._height
+
+    def look_at(self, x, y):
+        """Positions the camera such that the given coordinates are centered.
+
+        The coordinates may not be centered if the camera is at its boundary.
+
+        Args:
+            x (int): The x coordinate to center on.
+            y (int): The y coordinate to center on.
+        """
+        self._x = self._apply_boundary(x - self._x_offset, self._x_boundary)
+        self._y = self._apply_boundary(y - self._y_offset, self._y_boundary)
+
+    def update(self, ms):
+        """Updates the camera's position when following a target.
+
+        Args:
+            ms (int): Number of milliseconds since the last update.
+        """
+        pass
+
+    def attach(self):
+        """Applies camera transformations to subsequent draws.
+
+        Calling :fn:`camera.Camera.detach` stops applying the transformations.
+        """
+        gl.glPushMatrix()
+        gl.glTranslatef(-self._x, -self._y, 0)
+
+    def detach(self):
+        """Stops applying transformations set by :fn:`camera.Camera.attach`."""
+        gl.glPopMatrix()
+
+    def _apply_boundary(self, value, boundary):
+        """Applies the camera boundaries to the given coordinate.
+
+        Args:
+            value (int): The coordinate to apply the boundary to.
+            boundary (int or None): The boundary to restrict the coordinate to.
+
+        Returns:
+            An int of the coordinate within the boundary.
+        """
+        return value if boundary is None else max(min(boundary, value), 0)
+
+    @property
+    def x(self):
+        """Returns the x coordinate of the camera's lower left corner."""
+        return self._x
+
+    @property
+    def y(self):
+        """Returns the y coordinate of the camera's lower left corner."""
+        return self._y

--- a/engine/camera/camera.py
+++ b/engine/camera/camera.py
@@ -8,6 +8,8 @@ class Camera(object):
         x (int): The x coordinate of the camera's lower left corner.
         y (int): The y coordinate of the camera's lower left corner.
         scale (float): The scaling to apply to the visible scene.
+        follow (:obj:`game_object.GameObject` or None):
+            A target for the camera to follow, or None for manual control.
     """
 
     def __init__(self, width, height):
@@ -20,6 +22,8 @@ class Camera(object):
         self._width = width
         self._height = height
         self.scale = 1
+
+        self.follow = None
 
         self._x = 0
         self._y = 0
@@ -63,7 +67,8 @@ class Camera(object):
         Args:
             ms (int): Number of milliseconds since the last update.
         """
-        pass
+        if self.follow is not None:
+            self.look_at(self.follow.center.x, self.follow.center.y)
 
     def attach(self):
         """Applies camera transformations to subsequent draws.

--- a/engine/camera/camera.py
+++ b/engine/camera/camera.py
@@ -1,15 +1,22 @@
+from engine.geometry import Rectangle
 from pyglet import gl
 
 
-class Camera(object):
+class Camera(Rectangle):
     """Camera for controlling zoom and tracking game objects.
 
     Attributes:
         x (int): The x coordinate of the camera's lower left corner.
         y (int): The y coordinate of the camera's lower left corner.
+        coordinates (:obj:`engine.geometry.Point2d`):
+            The coordinates of the lower left corner as a :obj:`Point2d`.
+        width (int): The width of the camera.
+        height (int): The height of the camera.
         scale (float): The scaling to apply to the visible scene.
         follow (:obj:`game_object.GameObject` or None):
             A target for the camera to follow, or None for manual control.
+        follow_easing (:obj:`easing.EasingCurve` or None):
+            An easing curve to apply when following a target
     """
 
     def __init__(self, width, height):
@@ -19,20 +26,16 @@ class Camera(object):
             width (int): The width of the camera.
             height (int): The height of the camera.
         """
-        self._width = width
-        self._height = height
+        super(Camera, self).__init__(0, 0, width, height)
+
+        # Scale of the visible scene
         self.scale = 1
 
+        # Object tracking
         self.follow = None
+        self.follow_easing = None
 
-        self._x = 0
-        self._y = 0
-
-        # Offset for the camera to be centered
-        self._x_offset = width // 2
-        self._y_offset = height // 2
-
-        # Camera has no boundaries by default
+        # Boundary to restrict the camera to
         self._x_boundary = None
         self._y_boundary = None
 
@@ -46,8 +49,8 @@ class Camera(object):
             width (int): The x coordinate for the right edge of the boundary.
             height (int): The y coordinate for the upper edge of the boundary.
         """
-        self._x_boundary = width - self._width
-        self._y_boundary = height - self._height
+        self._x_boundary = width - self.width
+        self._y_boundary = height - self.height
 
     def look_at(self, x, y):
         """Positions the camera such that the given coordinates are centered.
@@ -58,8 +61,8 @@ class Camera(object):
             x (int): The x coordinate to center on.
             y (int): The y coordinate to center on.
         """
-        self._x = self._apply_boundary(x - self._x_offset, self._x_boundary)
-        self._y = self._apply_boundary(y - self._y_offset, self._y_boundary)
+        self.x = self._apply_boundary(x - self.width // 2, self._x_boundary)
+        self.y = self._apply_boundary(y - self.height // 2, self._y_boundary)
 
     def update(self, ms):
         """Updates the camera's position when following a target.
@@ -68,7 +71,15 @@ class Camera(object):
             ms (int): Number of milliseconds since the last update.
         """
         if self.follow is not None:
-            self.look_at(self.follow.center.x, self.follow.center.y)
+            if self.easing is not None:
+                # Update the curve if its end is no longer the target's center
+                if self.easing.end != self.follow.center:
+                    self.easing.reset(self.center, self.follow.center)
+
+                self.easing.update(ms)
+                self.look_at(*self.easing.value)
+            else:
+                self.look_at(*self.follow.center)
 
     def attach(self):
         """Applies camera transformations to subsequent draws.
@@ -77,7 +88,7 @@ class Camera(object):
         """
         gl.glPushMatrix()
         gl.glScalef(self.scale, self.scale, 0)
-        gl.glTranslatef(-self._x, -self._y, 0)
+        gl.glTranslatef(-self.x, -self.y, 0)
 
     def detach(self):
         """Stops applying transformations set by :fn:`camera.Camera.attach`."""
@@ -94,13 +105,3 @@ class Camera(object):
             An int of the coordinate within the boundary.
         """
         return value if boundary is None else max(min(boundary, value), 0)
-
-    @property
-    def x(self):
-        """Returns the x coordinate of the camera's lower left corner."""
-        return self._x
-
-    @property
-    def y(self):
-        """Returns the y coordinate of the camera's lower left corner."""
-        return self._y

--- a/engine/camera/camera.py
+++ b/engine/camera/camera.py
@@ -7,6 +7,7 @@ class Camera(object):
     Attributes:
         x (int): The x coordinate of the camera's lower left corner.
         y (int): The y coordinate of the camera's lower left corner.
+        scale (float): The scaling to apply to the visible scene.
     """
 
     def __init__(self, width, height):
@@ -18,6 +19,7 @@ class Camera(object):
         """
         self._width = width
         self._height = height
+        self.scale = 1
 
         self._x = 0
         self._y = 0
@@ -69,6 +71,7 @@ class Camera(object):
         Calling :fn:`camera.Camera.detach` stops applying the transformations.
         """
         gl.glPushMatrix()
+        gl.glScalef(self.scale, self.scale, 0)
         gl.glTranslatef(-self._x, -self._y, 0)
 
     def detach(self):

--- a/engine/camera/tests/test_camera.py
+++ b/engine/camera/tests/test_camera.py
@@ -20,6 +20,25 @@ class TestCamera(unittest.TestCase):
         self.assertEqual(50, camera.x, 'Camera is not horizontally centered')
         self.assertEqual(25, camera.y, 'Camera is not vertically centered')
 
+    def test_update_centers_on_followed_object(self):
+        """Updating the camera centers it on the followed object."""
+        # Create an object in the center of the camera
+        target = Mock(x=40, width=20, y=20, height=10)
+        camera = Camera(100, 50)
+        camera.follow = target
+        camera.update(123)
+
+        self.assertEqual(0, camera.x, 'Not horizontally centered on target')
+        self.assertEqual(0, camera.y, 'Not vertically centered on target')
+
+        # Move the object to be centered at (75, 40)
+        target.x = 65
+        target.y = 30
+        camera.update(123)
+
+        self.assertEqual(25, camera.x, 'Not horizontally centered after follow')
+        self.assertEqual(10, camera.y, 'Not vertically centered after follow')
+
     def test_camera_can_not_retract_past_boundary(self):
         """The camera will not retract past the boundary."""
         camera = Camera(100, 50)

--- a/engine/camera/tests/test_camera.py
+++ b/engine/camera/tests/test_camera.py
@@ -68,6 +68,94 @@ class TestCamera(unittest.TestCase):
         camera.follow_easing.reset.assert_called_with(Point2d(50, 25), Point2d(75, 35))
         camera.follow_easing.update.assert_called_with(456)
 
+    def test_update_eases_to_follow_target_with_positive_horizontal_lead(self):
+        """Updating the camera with leading eases ahead of followed object."""
+        # Create an object in the center of the camera
+        lead = 123
+        target = Mock(center=Point2d(50, 25), physics=Mock(velocity=Point2d(0, 0)))
+        camera = Camera(100, 50)
+        camera.follow = target
+        camera.follow_lead = Point2d(lead, 0)
+        camera.follow_easing = Mock(value=Point2d(50, 25))
+        camera.update(1)
+
+        # Easing was updated to view the center of the resting target
+        camera.follow_easing.reset.assert_called_once_with(Point2d(50, 25), Point2d(50, 25))
+
+        # Move the object to be centered at (75, 25)
+        target.physics.velocity.x = 10 # The x velocity will be a positive value
+        target.center = Point2d(75, 25)
+        camera.update(1)
+
+        # Easing had lead applied when following moving target
+        camera.follow_easing.reset.assert_called_with(Point2d(50, 25), Point2d(75 + lead, 25))
+
+    def test_update_eases_to_follow_target_with_negative_horizontal_lead(self):
+        """Updating the camera with leading eases ahead of followed object."""
+        # Create an object in the center of the camera
+        lead = 123
+        target = Mock(center=Point2d(50, 25), physics=Mock(velocity=Point2d(0, 0)))
+        camera = Camera(100, 50)
+        camera.follow = target
+        camera.follow_lead = Point2d(lead, 0)
+        camera.follow_easing = Mock(value=Point2d(50, 25))
+        camera.update(1)
+
+        # Easing was updated to view the center of the resting target
+        camera.follow_easing.reset.assert_called_once_with(Point2d(50, 25), Point2d(50, 25))
+
+        # Move the object to be centered at (25, 25)
+        target.physics.velocity.x = -10 # The x velocity will be a negative value
+        target.center = Point2d(25, 25)
+        camera.update(1)
+
+        # Easing had lead applied when following moving target
+        camera.follow_easing.reset.assert_called_with(Point2d(50, 25), Point2d(25 - lead, 25))
+
+    def test_update_eases_to_follow_target_with_positive_vertical_lead(self):
+        """Updating the camera with leading eases ahead of followed object."""
+        # Create an object in the center of the camera
+        lead = 123
+        target = Mock(center=Point2d(50, 25), physics=Mock(velocity=Point2d(0, 0)))
+        camera = Camera(100, 50)
+        camera.follow = target
+        camera.follow_lead = Point2d(0, lead)
+        camera.follow_easing = Mock(value=Point2d(50, 25))
+        camera.update(1)
+
+        # Easing was updated to view the center of the resting target
+        camera.follow_easing.reset.assert_called_once_with(Point2d(50, 25), Point2d(50, 25))
+
+        # Move the object to be centered at (50, 50)
+        target.physics.velocity.y = 10 # The y velocity will be a positive value
+        target.center = Point2d(50, 50)
+        camera.update(1)
+
+        # Easing had lead applied when following moving target
+        camera.follow_easing.reset.assert_called_with(Point2d(50, 25), Point2d(50, 50 + lead))
+
+    def test_update_eases_to_follow_target_with_negative_vertical_lead(self):
+        """Updating the camera with leading eases ahead of followed object."""
+        # Create an object in the center of the camera
+        lead = 123
+        target = Mock(center=Point2d(50, 25), physics=Mock(velocity=Point2d(0, 0)))
+        camera = Camera(100, 50)
+        camera.follow = target
+        camera.follow_lead = Point2d(0, lead)
+        camera.follow_easing = Mock(value=Point2d(50, 25))
+        camera.update(1)
+
+        # Easing was updated to view the center of the resting target
+        camera.follow_easing.reset.assert_called_once_with(Point2d(50, 25), Point2d(50, 25))
+
+        # Move the object to be centered at (50, 0)
+        target.physics.velocity.y = -10 # The y velocity will be a negative value
+        target.center = Point2d(50, 0)
+        camera.update(1)
+
+        # Easing had lead applied when following moving target
+        camera.follow_easing.reset.assert_called_with(Point2d(50, 25), Point2d(50, 0 - lead))
+
     def test_camera_can_not_retract_past_boundary(self):
         """The camera will not retract past the boundary."""
         camera = Camera(100, 50)

--- a/engine/camera/tests/test_camera.py
+++ b/engine/camera/tests/test_camera.py
@@ -6,6 +6,12 @@ import unittest
 class TestCamera(unittest.TestCase):
     """Test tracking functionality of the camera."""
 
+    def test_scale_defaults_to_1(self):
+        """The camera scale is 1 by default."""
+        camera = Camera(100, 50)
+
+        self.assertEqual(1, camera.scale)
+
     def test_look_at_centers_on_coordinates(self):
         """The camera target is centered within the frame."""
         camera = Camera(100, 50)
@@ -48,6 +54,15 @@ class TestCamera(unittest.TestCase):
         camera.attach()
 
         mock_translate.assert_called_once_with(-50, -25, 0)
+
+    @patch('pyglet.gl.glScalef')
+    def test_attach_scales_gl_context(self, mock_scale):
+        """Attaching the camera scales the OpenGL context."""
+        camera = Camera(100, 50)
+        camera.scale = 2
+        camera.attach()
+
+        mock_scale.assert_called_once_with(camera.scale, camera.scale, 0)
 
     @patch('pyglet.gl.glPopMatrix')
     def test_detach_pops_matrix(self, mock_pop_matrix):

--- a/engine/camera/tests/test_camera.py
+++ b/engine/camera/tests/test_camera.py
@@ -1,0 +1,59 @@
+from ..camera import Camera
+from unittest.mock import Mock, patch
+import unittest
+
+
+class TestCamera(unittest.TestCase):
+    """Test tracking functionality of the camera."""
+
+    def test_look_at_centers_on_coordinates(self):
+        """The camera target is centered within the frame."""
+        camera = Camera(100, 50)
+        camera.look_at(100, 50)
+
+        self.assertEqual(50, camera.x, 'Camera is not horizontally centered')
+        self.assertEqual(25, camera.y, 'Camera is not vertically centered')
+
+    def test_camera_can_not_retract_past_boundary(self):
+        """The camera will not retract past the boundary."""
+        camera = Camera(100, 50)
+        camera.set_boundary(200, 100)
+        camera.look_at(-200, -100)
+
+        self.assertEqual(0, camera.x, 'Camera receeded past horizontal bounds')
+        self.assertEqual(0, camera.y, 'Camera receeded past vertical bounds')
+
+    def test_camera_can_not_extend_past_boundary(self):
+        """The camera will not exceed past the boundary."""
+        camera = Camera(100, 50)
+        camera.set_boundary(200, 100)
+        camera.look_at(200, 100)
+
+        self.assertEqual(100, camera.x, 'Camera exceeded horizontal bounds')
+        self.assertEqual(50, camera.y, 'Camera exceeded vertical bounds')
+
+    @patch('pyglet.gl.glPushMatrix')
+    def test_attach_creates_new_matrix(self, mock_push_matrix):
+        """Attaching the camera creates a new OpenGL matrix."""
+        camera = Camera(100, 50)
+        camera.attach()
+
+        mock_push_matrix.assert_called_once()
+
+    @patch('pyglet.gl.glTranslatef')
+    def test_attach_translates_gl_context_to_coordinates(self, mock_translate):
+        """Attaching the camera translates the OpenGL context."""
+        camera = Camera(100, 50)
+        camera.look_at(100, 50)
+        camera.attach()
+
+        mock_translate.assert_called_once_with(-50, -25, 0)
+
+    @patch('pyglet.gl.glPopMatrix')
+    def test_detach_pops_matrix(self, mock_pop_matrix):
+        """Detaching the camera pops its OpenGL matrix."""
+        camera = Camera(100, 50)
+        camera.attach()
+        camera.detach()
+
+        mock_pop_matrix.assert_called_once()

--- a/engine/camera/tests/test_camera.py
+++ b/engine/camera/tests/test_camera.py
@@ -315,37 +315,47 @@ class TestCamera(unittest.TestCase):
         self.assertEqual(100, camera.x, 'Camera exceeded horizontal bounds')
         self.assertEqual(50, camera.y, 'Camera exceeded vertical bounds')
 
+    @patch('pyglet.gl.glScalef')
+    @patch('pyglet.gl.glTranslatef')
     @patch('pyglet.gl.glPushMatrix')
-    def test_attach_creates_new_matrix(self, mock_push_matrix):
+    def test_attach_creates_new_matrix(self, push, translate, scale):
         """Attaching the camera creates a new OpenGL matrix."""
         camera = Camera(100, 50)
         camera.attach()
 
-        mock_push_matrix.assert_called_once()
+        push.assert_called_once()
 
+    @patch('pyglet.gl.glScalef')
     @patch('pyglet.gl.glTranslatef')
-    def test_attach_translates_gl_context_to_coordinates(self, mock_translate):
+    @patch('pyglet.gl.glPushMatrix')
+    def test_attach_translates_gl_context_to_coordinates(self, push, translate,
+                                                         scale):
         """Attaching the camera translates the OpenGL context."""
         camera = Camera(100, 50)
         camera.look_at(100, 50)
         camera.attach()
 
-        mock_translate.assert_called_once_with(-50, -25, 0)
+        translate.assert_called_once_with(-50, -25, 0)
 
     @patch('pyglet.gl.glScalef')
-    def test_attach_scales_gl_context(self, mock_scale):
+    @patch('pyglet.gl.glTranslatef')
+    @patch('pyglet.gl.glPushMatrix')
+    def test_attach_scales_gl_context(self, push, translate, scale):
         """Attaching the camera scales the OpenGL context."""
         camera = Camera(100, 50)
         camera.scale = 2
         camera.attach()
 
-        mock_scale.assert_called_once_with(camera.scale, camera.scale, 0)
+        scale.assert_called_once_with(camera.scale, camera.scale, 0)
 
+    @patch('pyglet.gl.glScalef')
+    @patch('pyglet.gl.glTranslatef')
+    @patch('pyglet.gl.glPushMatrix')
     @patch('pyglet.gl.glPopMatrix')
-    def test_detach_pops_matrix(self, mock_pop_matrix):
+    def test_detach_pops_matrix(self, pop, push, translate, scale):
         """Detaching the camera pops its OpenGL matrix."""
         camera = Camera(100, 50)
         camera.attach()
         camera.detach()
 
-        mock_pop_matrix.assert_called_once()
+        pop.assert_called_once()

--- a/engine/easing/__init__.py
+++ b/engine/easing/__init__.py
@@ -1,3 +1,4 @@
+from .linear_interpolation import LinearInterpolation
 from .linear_curve import LinearCurve
 
-__all__ = ['LinearCurve']
+__all__ = ['LinearCurve', 'LinearInterpolation']

--- a/engine/easing/__init__.py
+++ b/engine/easing/__init__.py
@@ -1,0 +1,3 @@
+from .linear_curve import LinearCurve
+
+__all__ = ['LinearCurve']

--- a/engine/easing/easing_curve.py
+++ b/engine/easing/easing_curve.py
@@ -1,0 +1,55 @@
+class EasingCurve(object):
+    """Representation for an easing curve.
+
+    Attributes:
+        start (int): The starting value of the easing curve.
+        end (int): The ending value of the easing curve.
+        value (int): The current value of the easing curve.
+    """
+
+    def __init__(self, start=0, end=0):
+        """Creates a new easing curve.
+
+        Kwargs:
+            start (int, optional): The starting value of the curve.
+            end (int, optional): The ending value of the curve.
+        """
+        self.reset(start, end)
+
+    def _calculate_value(self):
+        """Method for base classes to override with their easing equations.
+
+        Returns:
+            An int representing the easing curve's value at the current time.
+        """
+        pass
+
+    def update(self, ms):
+        """Updates the easing curve to reflect the current position in time.
+
+        Args:
+            ms (int): Number of milliseconds since the last update.
+        """
+        if not self.is_done():
+            self._value = self._calculate_value()
+
+    def reset(self, start, end):
+        """Resets the curve, essentially creating a new curve.
+
+        Args:
+            start (int): The new starting value of the curve.
+            end (int): The new ending value of the curve.
+        """
+        self.start = start
+        self.end = end
+        self._delta = end - start
+        self._value = start
+
+    def is_done(self):
+        """Returns true if the easing curve is done."""
+        return self._value == self.end
+
+    @property
+    def value(self):
+        """Returns the current value of the easing curve."""
+        return self._value

--- a/engine/easing/linear_curve.py
+++ b/engine/easing/linear_curve.py
@@ -1,0 +1,29 @@
+from .timed_easing_curve import TimedEasingCurve
+
+
+class LinearCurve(TimedEasingCurve):
+    """An easing transition which moves at a constant rate.
+
+    Attributes:
+        value (int): The current value of the easing curve.
+    """
+
+    def __init__(self, duration, start=0, end=0):
+        """Creates a new linear easing curve.
+
+        Args:
+            duration (int): The total milliseconds to transition for.
+
+        Kwargs:
+            start (int, optional): The starting value of the curve.
+            end (int, optional): The ending value of the curve.
+        """
+        super(LinearCurve, self).__init__(duration, start, end)
+
+    def _calculate_value(self):
+        """Uses a linear equation to calculate the current value.
+
+        Returns:
+            An int representing the curve's value at the current time.
+        """
+        return self.start + self._delta * self._elapsed_time // self.duration

--- a/engine/easing/linear_interpolation.py
+++ b/engine/easing/linear_interpolation.py
@@ -1,0 +1,45 @@
+from .easing_curve import EasingCurve
+
+
+class LinearInterpolation(EasingCurve):
+    """An easing transition using linear interpolation.
+
+    Attributes:
+        value (int): The current value of the easing curve.
+    """
+
+    def __init__(self, factor, start=0, end=0):
+        """Creates a new linear interpolation curve.
+
+        Args:
+            factor (float): The interpolation factor to use.
+                            Values closer to 1 are more instantaneous.
+
+        Kwargs:
+            start (int, optional): The starting value of the curve.
+            end (int, optional): The ending value of the curve.
+        """
+        self._factor = int(factor * 100)
+        self._precision_value = 0
+        super(LinearInterpolation, self).__init__(start, end)
+
+    def _calculate_value(self):
+        """Uses linear interpolation to calculate the current value.
+
+        Returns:
+            An int representing the curve's current value.
+        """
+        # Reset the high resolution value if it no longer matches the int value
+        if self._value != self._precision_value // 100:
+            self._precision_value = self._value * 100
+
+        # Calculate the current value with 2 decimal places of precision
+        start = self._precision_value
+        end = self.end * 100
+        value = (start * (100 - self._factor) + end * self._factor) // 100
+
+        # Round the value to 1 decimal point of precision
+        self._precision_value = round(value, -1)
+
+        # Return the integer value of the high resolution value
+        return self._precision_value // 100

--- a/engine/easing/tests/test_easing_curve.py
+++ b/engine/easing/tests/test_easing_curve.py
@@ -1,0 +1,19 @@
+from ..easing_curve import EasingCurve
+import unittest
+
+
+class TestEasingCurve(unittest.TestCase):
+    """Test functionality of the base easing curve."""
+
+    def test_initial_curve_value_is_starting_value(self):
+        """An easing curve's initial value is its starting value."""
+        curve = EasingCurve(123, 456)
+
+        self.assertEqual(123, curve.value)
+
+    def test_easing_curve_value_is_read_only(self):
+        """The value of an easing curve is read only."""
+        curve = EasingCurve(0, 10)
+
+        with self.assertRaises(AttributeError, msg='can\'t set attribute'):
+            curve.value = 1

--- a/engine/easing/tests/test_linear_curve.py
+++ b/engine/easing/tests/test_linear_curve.py
@@ -1,0 +1,52 @@
+from ..linear_curve import LinearCurve
+import unittest
+
+
+class TestLinearCurve(unittest.TestCase):
+    """Test calculations for a linear easing curve."""
+
+    def test_positive_linear_curve_value_updates_linearly(self):
+        """A positive linear curve's value changes linearly in time."""
+        # From 0 to 10 in 10 time units
+        curve = LinearCurve(10, start=0, end=10)
+        curve.update(5)  # 5 units elapsed
+
+        self.assertEqual(5, curve.value)
+        curve.update(5)  # 10 units elapsed
+
+        self.assertEqual(10, curve.value)
+
+    def test_negative_linear_curve_value_updates_linearly(self):
+        """A negative linear curve's value changes linearly in time."""
+        # From 10 to 0 in 10 time units
+        curve = LinearCurve(10, start=10, end=0)
+        curve.update(5)  # 5 units elapsed
+
+        self.assertEqual(5, curve.value)
+        curve.update(5)  # 10 units elapsed
+
+        self.assertEqual(0, curve.value)
+
+    def test_linear_curve_does_not_update_after_duration(self):
+        """A linear curve's value doesn't change after the duration."""
+        # From 0 to 10 in 10 time units
+        curve = LinearCurve(10, start=0, end=10)
+        curve.update(10)  # 10 units elapsed
+
+        self.assertEqual(10, curve.value)
+        curve.update(5)  # 15 units elapsed
+
+        self.assertEqual(10, curve.value)
+
+    def test_linear_curve_is_done_once_duration_elapses(self):
+        """A linear curve is done once its duration has expired."""
+        curve = LinearCurve(10, start=0, end=10)
+
+        curve.update(9)  # 9 units elapsed
+        self.assertFalse(curve.is_done())
+
+        curve.update(1)  # 10 units elapsed (duration met)
+        self.assertTrue(curve.is_done(), "duration met")
+
+        curve.update(1)  # 11 units elapsed (duration exceeded)
+        self.assertTrue(curve.is_done(), "duration exceeded")

--- a/engine/easing/tests/test_linear_interpolation.py
+++ b/engine/easing/tests/test_linear_interpolation.py
@@ -1,0 +1,65 @@
+from ..linear_interpolation import LinearInterpolation
+import unittest
+
+
+class TestLinearInterpolation(unittest.TestCase):
+    """Test calculations for linear interpolation."""
+
+    def test_positive_linear_interpolation_with_factor_of_three_fourths(self):
+        """Positive linear interpolations approach end with factor of 0.75."""
+        curve = LinearInterpolation(0.75, start=0, end=10)
+        self.assertEqual(0, curve.value)
+
+        curve.update(0)  # Time does not matter for linear interpolation
+        self.assertEqual(7, curve.value)
+
+        curve.update(0)  # 9.38
+        curve.update(0)  # 9.84
+        self.assertEqual(9, curve.value)
+
+        curve.update(0)
+        self.assertEqual(10, curve.value)
+
+    def test_positive_linear_interpolation_with_factor_of_1(self):
+        """Positive linear interpolations change instantly with factor of 1."""
+        curve = LinearInterpolation(1.0, start=0, end=10)
+        self.assertEqual(0, curve.value)
+
+        curve.update(0)  # Time does not matter for linear interpolation
+        self.assertEqual(10, curve.value)
+
+    def test_negative_linear_interpolation_with_factor_of_three_fourths(self):
+        """Negative linear interpolations approach end with factor of 0.75."""
+        curve = LinearInterpolation(0.75, start=10, end=0)
+        self.assertEqual(10, curve.value)
+
+        curve.update(0)  # Time does not matter for linear interpolation
+        self.assertEqual(2, curve.value)
+
+        curve.update(0)  # 0.64
+        self.assertEqual(0, curve.value)
+
+    def test_negative_linear_interpolation_with_factor_of_1(self):
+        """Negative linear interpolations change instantly with factor of 1."""
+        curve = LinearInterpolation(1.0, start=10, end=0)
+        self.assertEqual(10, curve.value)
+
+        curve.update(0)  # Time does not matter for linear interpolation
+        self.assertEqual(0, curve.value)
+
+    def test_linear_interpolation_does_not_exceed_its_end(self):
+        """Linear interpolation does not exceed its end value."""
+        curve = LinearInterpolation(1.0, start=0, end=10)
+        curve.update(0)
+        self.assertEqual(10, curve.value)
+
+        curve.update(0)  # Updating will not move past the endpoint
+        self.assertEqual(10, curve.value)
+
+    def test_linear_interpolation_is_done_once_endpoint_is_reached(self):
+        """Linear interpolation is done once its end is reached."""
+        curve = LinearInterpolation(1.0, start=0, end=10)
+        self.assertFalse(curve.is_done())
+
+        curve.update(0)
+        self.assertTrue(curve.is_done())

--- a/engine/easing/tests/test_timed_easing_curve.py
+++ b/engine/easing/tests/test_timed_easing_curve.py
@@ -1,0 +1,19 @@
+from ..timed_easing_curve import TimedEasingCurve
+import unittest
+
+
+class TestTimedEasingCurve(unittest.TestCase):
+    """Test functionality of the base timed easing curve."""
+
+    def test_initial_timed_curve_value_is_starting_value(self):
+        """A timed easing curve's initial value is its starting value."""
+        curve = TimedEasingCurve(123, start=456, end=789)
+
+        self.assertEqual(456, curve.value)
+
+    def test_timed_easing_curve_value_is_read_only(self):
+        """The value of a timed easing curve is read only."""
+        curve = TimedEasingCurve(10, start=0, end=10)
+
+        with self.assertRaises(AttributeError, msg='can\'t set attribute'):
+            curve.value = 1

--- a/engine/easing/timed_easing_curve.py
+++ b/engine/easing/timed_easing_curve.py
@@ -1,0 +1,53 @@
+from .easing_curve import EasingCurve
+
+
+class TimedEasingCurve(EasingCurve):
+    """Representation for an easing curve with a duration.
+
+    Attributes:
+        start (int): The starting value of the easing curve.
+        end (int): The ending value of the easing curve.
+        value (int): The current value of the easing curve.
+        duration (int): The duration of the easing curve in ms.
+    """
+
+    def __init__(self, duration, start=0, end=0):
+        """Creates a new timed easing curve.
+
+        Args:
+            duration (int): The total milliseconds to transition for.
+
+        Kwargs:
+            start (int, optional): The starting value of the curve.
+            end (int, optional): The ending value of the curve.
+        """
+        super(TimedEasingCurve, self).__init__(start, end)
+        self.reset(start, end, duration)
+
+    def update(self, ms):
+        """Updates the easing curve to reflect the current position in time.
+
+        Args:
+            ms (int): Number of milliseconds since the last update.
+        """
+        # Ensure the elapsed time does not exceed the duration
+        self._elapsed_time = min(self.duration, self._elapsed_time + ms)
+
+        super(TimedEasingCurve, self).update(ms)
+
+    def reset(self, start, end, duration=None):
+        """Resets the curve, essentially creating a new curve.
+
+        Args:
+            start (int): The new starting value of the curve.
+            end (int): The new ending value of the curve.
+
+        Kwargs:
+            duration (int, optional): An optional new duration for the curve.
+        """
+        super(TimedEasingCurve, self).reset(start, end)
+
+        self._elapsed_time = 0
+
+        if duration is not None:
+            self.duration = duration

--- a/engine/game_object/game_object.py
+++ b/engine/game_object/game_object.py
@@ -16,7 +16,7 @@ class GameObject(geometry.Rectangle, EventDispatcher):
             Read-only.
         width (int): The width of the object's geometry.
         height (int): The height of the object's geometry.
-        physics (:obj:`engine.geometry.Physics2d`):
+        physics (:obj:`engine.physics.Physics2d`):
             Physics that the object obeys on update.
 
     Events:

--- a/engine/geometry/point_2d.py
+++ b/engine/geometry/point_2d.py
@@ -210,3 +210,12 @@ class Point2d(object):
         """
         self.x, self.y = self._call_with_other(operator.floordiv, other)
         return self
+
+    def __round__(self, digits=None):
+        """Rounds the x and y coordinates to the number of digits.
+
+        Kwargs:
+            digits (int, optional): The number of digits to round the point to.
+        """
+        self.x, self.y = round(self.x, digits), round(self.y, digits)
+        return self

--- a/engine/geometry/rectangle.py
+++ b/engine/geometry/rectangle.py
@@ -33,6 +33,11 @@ class Rectangle(object):
         return self._coordinates
 
     @property
+    def center(self):
+        """Returns the coordinates of the center of the rectangle."""
+        return self.coordinates + (self.width // 2, self.height // 2)
+
+    @property
     def x(self):
         """Returns the x coordinate of rectangle."""
         return self._coordinates.x

--- a/engine/geometry/rectangle.py
+++ b/engine/geometry/rectangle.py
@@ -41,3 +41,13 @@ class Rectangle(object):
     def y(self):
         """Returns the y coordinate of rectangle."""
         return self._coordinates.y
+
+    @x.setter
+    def x(self, x):
+        """Sets the x coordinate of rectangle."""
+        self._coordinates.x = x
+
+    @y.setter
+    def y(self, y):
+        """Sets the y coordinate of rectangle."""
+        self._coordinates.y = y

--- a/engine/geometry/tests/test_point_2d.py
+++ b/engine/geometry/tests/test_point_2d.py
@@ -241,3 +241,13 @@ class TestPoint2d(unittest.TestCase):
         self.assertEqual(2, point.y)
         self.assertEqual(3, point2.x)
         self.assertEqual(2, point2.y)
+
+    def test_point_rounding(self):
+        """Rounding points rounds both coordinates."""
+        point = Point2d(1.1, 1.9)
+
+        point2 = round(point)
+
+        self.assertEqual(1, point.x)
+        self.assertEqual(2, point.y)
+        self.assertEqual(point, point2)

--- a/engine/geometry/tests/test_rectangle.py
+++ b/engine/geometry/tests/test_rectangle.py
@@ -15,6 +15,12 @@ class TestRectangle(unittest.TestCase):
         self.assertEqual(1, rect.coordinates.x)
         self.assertEqual(2, rect.coordinates.y)
 
+    def test_rectangle_center(self):
+        """The center of a Rectangle is provided as a property."""
+        rect = Rectangle(0, 0, 10, 20)
+        self.assertEqual(5, rect.center.x)
+        self.assertEqual(10, rect.center.y)
+
     def test_rectangle_can_be_positioned_by_x_and_y_values(self):
         """A Rectangle can be repositioned using its x and y attributes."""
         rect = Rectangle(1, 2, 3, 4)

--- a/engine/geometry/tests/test_rectangle.py
+++ b/engine/geometry/tests/test_rectangle.py
@@ -14,3 +14,18 @@ class TestRectangle(unittest.TestCase):
         self.assertEqual(4, rect.height)
         self.assertEqual(1, rect.coordinates.x)
         self.assertEqual(2, rect.coordinates.y)
+
+    def test_rectangle_can_be_positioned_by_x_and_y_values(self):
+        """A Rectangle can be repositioned using its x and y attributes."""
+        rect = Rectangle(1, 2, 3, 4)
+        self.assertEqual(1, rect.x)
+        self.assertEqual(2, rect.y)
+        self.assertEqual(1, rect.coordinates.x)
+        self.assertEqual(2, rect.coordinates.y)
+
+        rect.x = 10
+        rect.y = 20
+        self.assertEqual(10, rect.x)
+        self.assertEqual(20, rect.y)
+        self.assertEqual(10, rect.coordinates.x)
+        self.assertEqual(20, rect.coordinates.y)

--- a/engine/room/room.py
+++ b/engine/room/room.py
@@ -27,3 +27,13 @@ class Room(object):
     def draw(self):
         """Draws all layers in the room."""
         self.layers.draw()
+
+    @property
+    def width(self):
+        """Returns the pixel width of the room."""
+        return self.layers.width
+
+    @property
+    def height(self):
+        """Returns the pixel height of the room."""
+        return self.layers.height

--- a/engine/room/room_layer_collection.py
+++ b/engine/room/room_layer_collection.py
@@ -4,10 +4,18 @@ from collections import OrderedDict
 class RoomLayerCollection(object):
     """Collection of multiple layers for a room."""
 
-    def __init__(self):
+    def __init__(self, width, height):
+        """Creates a new collection of ordered room layers.
+
+        Args:
+            width (int): The width of the collection in pixels.
+            height (int): The height of the collection in pixels.
+        """
         super(RoomLayerCollection, self).__init__()
 
         self._layers = OrderedDict()
+        self._width = width
+        self._height = height
 
     def add_layer(self, name, layer):
         """Adds a layer to the end of the collection, rendering it on top.
@@ -48,3 +56,13 @@ class RoomLayerCollection(object):
         """
         for name, layer in self._layers.items():
             layer.draw()
+
+    @property
+    def width(self):
+        """Returns the pixel width of the collection."""
+        return self._width
+
+    @property
+    def height(self):
+        """Returns the pixel height of the collection."""
+        return self._height

--- a/engine/room/tests/test_room_layer_collection.py
+++ b/engine/room/tests/test_room_layer_collection.py
@@ -11,7 +11,7 @@ class TestRoomLayerCollection(unittest.TestCase):
         mock_layers = Mock(a=Mock(), b=Mock(), c=Mock())
 
         # Create a collection with 3 layers (a, b, and c)
-        collection = RoomLayerCollection()
+        collection = RoomLayerCollection(1, 1)
         collection.add_layer('a', mock_layers.a)
         collection.add_layer('b', mock_layers.b)
         collection.add_layer('c', mock_layers.c)
@@ -25,7 +25,7 @@ class TestRoomLayerCollection(unittest.TestCase):
         mock_layers = Mock(a=Mock(), b=Mock(), c=Mock())
 
         # Create a collection with 3 layers
-        collection = RoomLayerCollection()
+        collection = RoomLayerCollection(1, 1)
         collection.add_layer('a', mock_layers.a)
         collection.add_layer('b', mock_layers.b)
         collection.add_layer('c', mock_layers.c)
@@ -40,7 +40,7 @@ class TestRoomLayerCollection(unittest.TestCase):
         mock_layers = Mock(a=Mock(), b=Mock(), c=Mock())
 
         # Create a collection with 3 layers
-        collection = RoomLayerCollection()
+        collection = RoomLayerCollection(1, 1)
         collection.add_layer('a', mock_layers.a)
         collection.add_layer('b', mock_layers.b)
         collection.add_layer('c', mock_layers.c)
@@ -49,3 +49,21 @@ class TestRoomLayerCollection(unittest.TestCase):
 
         mock_layers.assert_has_calls(
             [call.a.draw(), call.b.draw(), call.c.draw()])
+
+    def test_collection_width_is_read_only(self):
+        """Layer collection width is read-only."""
+        collection = RoomLayerCollection(1, 0)
+
+        self.assertEqual(1, collection.width)
+
+        with self.assertRaises(AttributeError, msg='can\'t set attribute'):
+            collection.width = 2
+
+    def test_collection_height_is_read_only(self):
+        """Layer collection height is read-only."""
+        collection = RoomLayerCollection(0, 1)
+
+        self.assertEqual(1, collection.height)
+
+        with self.assertRaises(AttributeError, msg='can\'t set attribute'):
+            collection.height = 2

--- a/engine/tiled_editor/tests/test_tmx_layer_loader.py
+++ b/engine/tiled_editor/tests/test_tmx_layer_loader.py
@@ -17,7 +17,7 @@ class TestTmxLayer(unittest.TestCase):
         """Graphics are created when loading tile layers."""
         # 2x2 tiles on a 6x3 map
         mock_xml = '<map width="6" height="3" tilewidth="2">\n'
-        mock_xml += '\t<layer name="test" />\n'
+        mock_xml += '\t<layer name="test" width="6" height="3" />\n'
         mock_xml += '</map>\n'
         mock_map_node = ElementTree.parse(StringIO(mock_xml)).getroot()
         mock_layer_node = mock_map_node.find('layer')
@@ -61,7 +61,7 @@ class TestTmxLayer(unittest.TestCase):
         """Objects are created when loading object layers."""
         # 2x2 tiles on a 6x3 map
         mock_xml = '<map width="6" height="3" tilewidth="2">\n'
-        mock_xml += '\t<objectgroup name="test" />\n'
+        mock_xml += '\t<objectgroup name="test" width="6" height="3" />\n'
         mock_xml += '</map>\n'
         mock_map_node = ElementTree.parse(StringIO(mock_xml)).getroot()
         mock_layer_node = mock_map_node.find('objectgroup')

--- a/engine/tiled_editor/tests/test_tmx_loader.py
+++ b/engine/tiled_editor/tests/test_tmx_loader.py
@@ -47,8 +47,8 @@ class TestTmxLoader(unittest.TestCase):
     def test_tile_layers_use_tilesets(self, MockDiskLoader, MockLayerLoader,
                                       mock_load_tileset):
         """Tile layers are loaded using the loaded tilesets."""
-        mock_xml = '<map version="1.2" orientation="orthogonal" '
-        mock_xml += 'infinite="0">\n'
+        mock_xml = '<map version="1.2" orientation="orthogonal" infinite="0" '
+        mock_xml += 'tilewidth="10" tileheight="10" width="1" height="2">\n'
         mock_xml += '\t<tileset/>\n'
         mock_xml += '\t<layer/>\n'
         mock_xml += '</map>\n'
@@ -87,8 +87,8 @@ class TestTmxLoader(unittest.TestCase):
     @patch('engine.disk.DiskLoader')
     def test_object_layers_are_loaded(self, MockDiskLoader, MockLayerLoader):
         """Tile layers are loaded using the loaded tilesets."""
-        mock_xml = '<map version="1.2" orientation="orthogonal" '
-        mock_xml += 'infinite="0">\n'
+        mock_xml = '<map version="1.2" orientation="orthogonal" infinite="0" '
+        mock_xml += 'tilewidth="10" tileheight="10" width="1" height="2">\n'
         mock_xml += '\t<objectgroup/>\n'
         mock_xml += '</map>\n'
         mock_root_node = ElementTree.parse(StringIO(mock_xml)).getroot()
@@ -112,3 +112,26 @@ class TestTmxLoader(unittest.TestCase):
         # Loaded layer was added to the collection
         self.assertEqual(
             MockLayerLoader().layer, tmx_loader.layers.get_layer('test'))
+
+    @patch('engine.tiled_editor.tmx_loader.load_tmx_tileset')
+    @patch('engine.tiled_editor.tmx_loader.TmxLayerLoader')
+    @patch('engine.disk.DiskLoader')
+    def test_layer_collection_has_map_dimensions(self, MockDiskLoader,
+                                                 MockLayerLoader,
+                                                 mock_load_tileset):
+        """Tile layer collection has the pixel dimensions of the map."""
+        mock_xml = '<map version="1.2" orientation="orthogonal" infinite="0" '
+        mock_xml += 'tilewidth="10" tileheight="10" width="1" height="2">\n'
+        mock_xml += '\t<tileset/>\n'
+        mock_xml += '\t<layer/>\n'
+        mock_xml += '</map>\n'
+        mock_root_node = ElementTree.parse(StringIO(mock_xml)).getroot()
+
+        MockDiskLoader.load_xml.return_value = mock_root_node
+
+        # Create a TMX loader with no object factory
+        tmx_loader = TmxLoader('map.tmx', None)
+
+        # Layer collection has pixel dimensions of the map
+        self.assertEqual(10, tmx_loader.layers.width)
+        self.assertEqual(20, tmx_loader.layers.height)

--- a/engine/tiled_editor/tmx_loader.py
+++ b/engine/tiled_editor/tmx_loader.py
@@ -38,7 +38,10 @@ class TmxLoader(object):
         if map_attr['infinite'] != '0':
             raise NotImplementedError('Infinite maps are not supported')
 
-        self.layers = room.RoomLayerCollection()
+        width = int(map_attr['width']) * int(map_attr['tilewidth'])
+        height = int(map_attr['height']) * int(map_attr['tileheight'])
+
+        self.layers = room.RoomLayerCollection(width, height)
 
         self._object_factory = object_factory
         self._path = tmx_path


### PR DESCRIPTION
Things are getting really close to a playable state! 🎉 This PR introduces a camera with tracking capabilities, sporting these headliners:

1. Targets can be followed using an easing curve, such as a linear curve or linear intepretation
1. The camera can lead ahead of a target, allowing the player to see more of where they're going
1. The camera also supports a deadzone, keeping it still until the player has moved outside of its bounds

![pickle-camera](https://user-images.githubusercontent.com/2885412/91630544-090e2480-e987-11ea-9b2a-a36d9f2b32a7.gif)
