### PR TITLE
Cache collisions by positions instead of delta

### DIFF
--- a/engine/collision/tests/test_collision_resolver_2d.py
+++ b/engine/collision/tests/test_collision_resolver_2d.py
@@ -204,8 +204,8 @@ class TestCollisionResolver2d(unittest.TestCase):
         """No notifications fire when the prior collision occurs again."""
         self.resolver = CollisionResolver2d()
 
-        a = Mock(name='a', x=1, width=2, y=3, height=2)
-        b = Mock(name='b', x=2, width=2, y=2, height=2)
+        a = Mock(name='a', coordinates=(1, 3), x=1, width=2, y=3, height=2)
+        b = Mock(name='b', coordinates=(2, 2), x=2, width=2, y=2, height=2)
         self.resolver.register(a, RESOLVE_COLLISIONS)
         self.resolver.register(b, RESOLVE_COLLISIONS)
 
@@ -216,7 +216,7 @@ class TestCollisionResolver2d(unittest.TestCase):
         a.notify_collision_with.assert_called_once_with(b)
         b.notify_collision_with.assert_called_once_with(a)
 
-        # Same resolution as before
+        # Same resolution as before, from same positions as before
         resolve_mock.return_value = (1, 1)
 
         self.resolver.resolve()
@@ -241,3 +241,47 @@ class TestCollisionResolver2d(unittest.TestCase):
         self.resolver.resolve()
         a.notify_collision_with.assert_not_called()
         b.notify_collision_with.assert_not_called()
+
+    @patch(resolve_game_object_collision_fn)
+    def test_notify_collision_matching_previous_collision(self, resolve_mock):
+        """A collision identical to the previous collision between two objects
+        is notified if movement occurred between collisions.
+
+        This test captures the scenario where a character jumps and lands in
+        the exact coordinates as their previous resolution with the floor.
+        """
+        self.resolver = CollisionResolver2d()
+
+        a = Mock(name='a', coordinates=(1, 3), x=1, width=2, y=3, height=2)
+        b = Mock(name='b', coordinates=(2, 2), x=2, width=2, y=2, height=2)
+        self.resolver.register(a, RESOLVE_COLLISIONS)
+        self.resolver.register(b, RESOLVE_COLLISIONS)
+
+        # Objects are resolved by changing velocity
+        resolve_mock.return_value = (1, 1)
+
+        self.resolver.resolve()
+        a.notify_collision_with.assert_called_once_with(b)
+        b.notify_collision_with.assert_called_once_with(a)
+
+        # Object is moved to no longer collide
+        resolve_mock.return_value = (0, 0)
+        a.coordinates = (4, 4)
+        a.x = 4
+        a.y = 4
+
+        self.resolver.resolve()
+        self.assertEqual(1, a.notify_collision_with.call_count)
+        self.assertEqual(1, b.notify_collision_with.call_count)
+
+        # Object returns with same resolution as before
+        a.coordinates = (1, 3)
+        a.x = 1
+        a.y = 3
+        resolve_mock.return_value = (1, 1)
+
+        self.resolver.resolve()
+
+        # Still only called once, meaning they weren't called a second time
+        a.notify_collision_with.assert_has_calls([call(b), call(b)])
+        b.notify_collision_with.assert_has_calls([call(a), call(a)])


### PR DESCRIPTION
The collision cache is used to avoid notifying of a collision which is
invisible to the player, i.e. when Pickle is pushed up onto the floor.

This was originally done by caching the velocity delta between two
objects, which was susceptible to a bug where the collision would not
notify identical deltas if there was movement in between (i.e. Pickle
jumped and then landed with the same velocity delta). Using a
position-based approach more accurately determines if a collision is
visually distinct or if the object was resolved to its previous position

tl;dr: Pickle no longer loses her jump randomly