### PR TITLE
Collider debug graphics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 cache: pip
 python:
-  - 3.6.3
+  - 3.8.5
 env:
   PYGLET_SHADOW_WINDOW: 'False'
+  PYGLET_DEBUG_GL: 'False'
   PYGLET_AUDIO: 'silent'
 addons:
   apt:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ coverage report -m --skip-covered --include=./* # Report files without 100% cove
 
 ## Dev Log
 
+<img align="left" alt="Pickle's collider is shown as a green outline" src="https://user-images.githubusercontent.com/2885412/92317435-67ee2200-efb5-11ea-8b94-430b1554da3f.gif" width="30%">
+<p align="left" width="60%"><strong>Sept 2020</strong><br>Debug graphics for colliders and triggers were added, showing what the world simulation is really looking at.</p>
+<p> </p>
 <img align="right" alt="Pickle hops around an early rendition of the game's castle" src="https://user-images.githubusercontent.com/2885412/91630544-090e2480-e987-11ea-9b2a-a36d9f2b32a7.gif" width="30%">
 <p align="right" width="60%"><strong>Aug 2020</strong><br>The camera was implemented, allowing Pickle to explore maps created with the Tiled editor.</p>
 <p> </p>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status][build-badge]][build-link] [![Coverage][coverage-badge]][coverage-link] [![Maintainability][health-badge]][health-link]
 
-A throwback to the Game Boy era of gaming, inspired by Kirby's Great Cave Offensive and created for GitHub's 2017 Game Off. Help Pickle brave the Wolf Queen's Palace and collect as many of her treasures as you can!
+A throwback to the Game Boy era of gaming, inspired by Kirby's Great Cave Offensive and started for GitHub's 2017 Game Off. Help Pickle brave the Wolf Queen's Palace and collect as many of her treasures as you can!
 
 ## Installing
 

--- a/engine/collision/positional_collision_cache.py
+++ b/engine/collision/positional_collision_cache.py
@@ -87,7 +87,7 @@ class PositionalCollisionCache(CollisionCache):
 
         # Iterate over the cached and new positions on the x and y axes
         return self._is_repeated_on_axis(key, velocity_delta, 'x') and \
-               self._is_repeated_on_axis(key, velocity_delta, 'y')
+            self._is_repeated_on_axis(key, velocity_delta, 'y')
 
     def _is_repeated_on_axis(self, key, velocity_delta, axis):
         """Checks if a collision between two objects is identical to the last.

--- a/engine/graphics/__init__.py
+++ b/engine/graphics/__init__.py
@@ -1,5 +1,6 @@
+from .cross_box import CrossBox
 from .graphics_controller import GraphicsController
 from .graphics_object import GraphicsObject
 from .graphics_batch import GraphicsBatch
 
-__all__ = ['GraphicsBatch', 'GraphicsController', 'GraphicsObject']
+__all__ = ['CrossBox', 'GraphicsBatch', 'GraphicsController', 'GraphicsObject']

--- a/engine/graphics/cross_box.py
+++ b/engine/graphics/cross_box.py
@@ -1,0 +1,68 @@
+from pyglet.graphics import vertex_list
+from pyglet.gl import GL_LINES
+
+
+class CrossBox(object):
+    """Draws the outline of a rectangle with diagonal lines through its center.
+
+    This is done using OpenGL primitives and is ideal for debug purposes.
+    """
+
+    VERTEX_COUNT = 12
+
+    def __init__(self, rectangle, color=(0, 0, 0), batch=None):
+        """Creates a new cross box graphic.
+
+        Args:
+            rectangle (:obj:`engine.geometry.Rectangle`):
+                Rectangular area to render the cross box around.
+
+        Kwargs:
+            color (tuple of 3 int, optional):
+                An rgb tuple of the color to draw with. Defaults to black.
+            batch (:obj:`engine.graphics.GraphicsBatch`, optional):
+                The batch to render this graphic with. Defaults to None.
+        """
+        super(CrossBox, self).__init__()
+        self._x, self._y = rectangle.x, rectangle.y
+
+        gl_vertices = ('v2i', self._get_vertices(rectangle))
+        gl_colors = ('c3B', color * self.VERTEX_COUNT)
+
+        if batch:
+            self._graphic = batch.add(
+                self.VERTEX_COUNT, GL_LINES, None, gl_vertices, gl_colors)
+        else:
+            self._graphic = vertex_list(
+                self.VERTEX_COUNT, gl_vertices, gl_colors)
+
+    def set_position(self, coordinates):
+        """Sets the position of the cross box's bottom left corner.
+
+        Args:
+            coordinates (tuple of int):
+                New x and y coordinates for the lower left corner.
+        """
+        coordinate_delta = (coordinates[0] - self._x, coordinates[1] - self._y)
+
+        # Update each vertex coordinate by the corresponding coordinate delta
+        self._graphic.vertices = list(map(
+            lambda current, delta: current + delta,
+            self._graphic.vertices,
+            coordinate_delta * self.VERTEX_COUNT))
+
+        self._x, self._y = coordinates
+
+    def _get_vertices(self, rectangle):
+        """Returns the vertices for a cross box around the rectangle."""
+        x, x2 = rectangle.x, rectangle.x + rectangle.width
+        y, y2 = rectangle.y, rectangle.y + rectangle.height
+
+        return (
+            x,  y,  x2, y,
+            x,  y,  x,  y2,
+            x2, y,  x,  y2,
+            x,  y2, x2, y2,
+            x2, y2, x,  y,
+            x2, y2, x2, y
+        )

--- a/engine/graphics/graphics_batch.py
+++ b/engine/graphics/graphics_batch.py
@@ -1,10 +1,38 @@
-import pyglet.graphics
+from pyglet.gl import glPushAttrib, glPopAttrib, glEnable, GL_ENABLE_BIT
+from pyglet.gl import glLineStipple, GL_LINE_STIPPLE
+from pyglet.graphics import Batch
 
 
-class GraphicsBatch(pyglet.graphics.Batch):
+class GraphicsBatch(Batch):
     """Manages a set of objects to draw together for efficiency.
 
     A :obj:`engine.graphics.GraphicsBatch` object can be passed as a
     constructor argument to a :obj:`engine.graphics.GraphicsObject` to add that
     object to the batch.
+
+    Batches can be rendered with additional special properties:
+
+    * ``DASHED_LINES``: OpenGL lines will be drawn dashed rather than solid.
     """
+
+    DASHED_LINES = 1
+
+    def draw_special(self, style):
+        """Draws the batch with special OpenGL attributes.
+
+        Args:
+            style (int): The style with which to draw the batch.
+        """
+        glPushAttrib(GL_ENABLE_BIT)
+
+        if style == self.DASHED_LINES:
+            self._set_dashed_lines()
+
+        self.draw()
+
+        glPopAttrib()
+
+    def _set_dashed_lines(self):
+        """Sets OpenGL to draw dashed lines."""
+        glLineStipple(1, 0x00FF)
+        glEnable(GL_LINE_STIPPLE)

--- a/engine/graphics/graphics_object.py
+++ b/engine/graphics/graphics_object.py
@@ -33,15 +33,15 @@ class GraphicsObject(object):
                     {
                         'default':   idle_image,
                         'activated': activated_image,
-                        'flashing': GraphicsObjects.create_animation(
+                        'flashing': GraphicsObject.create_animation(
                             flashing_image_grid[0:4], 500, loop=True)
                     }
 
         Kwargs:
-            batch (:obj:`pyglet.graphics.Batch`, optional): The batch to render
-                this graphic with. Defaults to None.
-            group (:obj:`pyglet.graphics.Group`, optional): The group to render
-                this graphic within. Defaults to None.
+            batch (:obj:`engine.graphics.GraphicsBatch`, optional):
+                The batch to render this graphic with. Defaults to None.
+            group (:obj:`pyglet.graphics.Group`, optional):
+                The group to render this graphic within. Defaults to None.
 
         Raises:
             KeyError: If ``display_states`` was missing the 'default' state.

--- a/engine/graphics/tests/test_cross_box.py
+++ b/engine/graphics/tests/test_cross_box.py
@@ -1,0 +1,111 @@
+from ..cross_box import CrossBox
+from unittest.mock import Mock, patch
+from pyglet.gl import GL_LINES
+import unittest
+
+
+class TestCrossBox(unittest.TestCase):
+    """Test rendering of cross box graphics."""
+
+    def setUp(self):
+        """Provides the following to all tests:
+
+        * ``self.rectangle``: Mock rectangle.
+        * ``self.vertex_count``: Number of vertices for the rectangle.
+        * ``self.expected_vertices``: Expected verticies for the rectangle.
+        * ``self.default_color``: Expected default color for the cross box.
+        * ``self.new_coordinates``: New coordinates to reposition to.
+        * ``self.new_expected_vertices``: Expected verticies after reposition.
+        """
+        self.rectangle = Mock(x=1, y=2, width=3, height=4)
+
+        self.expected_vertices = (
+            1, 2, 4, 2,
+            1, 2, 1, 6,
+            4, 2, 1, 6,
+            1, 6, 4, 6,
+            4, 6, 1, 2,
+            4, 6, 4, 2)
+        self.vertex_count = (len(self.expected_vertices) // 2)
+
+        self.default_color = (0, 0, 0) * self.vertex_count
+
+        self.new_coordinates = (2, 4)
+        self.new_expected_vertices = [
+            2, 4, 5, 4,
+            2, 4, 2, 8,
+            5, 4, 2, 8,
+            2, 8, 5, 8,
+            5, 8, 2, 4,
+            5, 8, 5, 4]
+
+    @patch('engine.graphics.cross_box.vertex_list')
+    def test_creates_vertex_list_without_batch(self, mock_vertex_list):
+        """Cross box uses a vertex list if no batch is given."""
+        CrossBox(self.rectangle)
+
+        mock_vertex_list.assert_called_once_with(
+            self.vertex_count,
+            ('v2i', self.expected_vertices),
+            ('c3B', self.default_color))
+
+    @patch('engine.graphics.cross_box.vertex_list')
+    def test_sets_color_of_vertex_list(self, mock_vertex_list):
+        """Cross box sets custom colors for a vertex list."""
+        color = (1, 2, 3)
+        expected_colors = color * self.vertex_count
+
+        CrossBox(self.rectangle, color)
+
+        mock_vertex_list.assert_called_once_with(
+            self.vertex_count,
+            ('v2i', self.expected_vertices),
+            ('c3B', expected_colors))
+
+    @patch('engine.graphics.cross_box.vertex_list')
+    def test_repositions_vertex_list(self, mock_vertex_list):
+        """Repositioning a cross box updates the vertex list."""
+        mock_vertex_list.return_value.vertices = self.expected_vertices
+        cross_box = CrossBox(self.rectangle)
+        cross_box.set_position(self.new_coordinates)
+
+        self.assertEqual(
+            self.new_expected_vertices, mock_vertex_list.return_value.vertices)
+
+    def test_uses_batch(self):
+        """Cross box uses a batch if given."""
+        batch = Mock()
+        CrossBox(self.rectangle, batch=batch)
+
+        batch.add.assert_called_once_with(
+            self.vertex_count,
+            GL_LINES,
+            None,
+            ('v2i', self.expected_vertices),
+            ('c3B', self.default_color))
+
+    def test_sets_color_with_batch(self):
+        """Cross box sets custom colors when using a batch."""
+        color = (1, 2, 3)
+        expected_colors = color * self.vertex_count
+
+        batch = Mock()
+        CrossBox(self.rectangle, color, batch)
+
+        batch.add.assert_called_once_with(
+            self.vertex_count,
+            GL_LINES,
+            None,
+            ('v2i', self.expected_vertices),
+            ('c3B', expected_colors))
+
+    def test_repositions_batch(self):
+        """Repositioning a cross box updates the batched vertices."""
+        batch = Mock()
+        batch.add.return_value.vertices = self.expected_vertices
+
+        cross_box = CrossBox(self.rectangle, batch=batch)
+        cross_box.set_position(self.new_coordinates)
+
+        self.assertEqual(
+            self.new_expected_vertices, batch.add.return_value.vertices)

--- a/engine/graphics/tests/test_graphics_batch.py
+++ b/engine/graphics/tests/test_graphics_batch.py
@@ -1,0 +1,25 @@
+from ..graphics_batch import GraphicsBatch
+from unittest.mock import Mock, patch
+from pyglet.gl import GL_ENABLE_BIT, GL_LINE_STIPPLE
+import unittest
+
+
+class TestGraphicsBatch(unittest.TestCase):
+    """Test graphics batch functionality."""
+
+    @patch('engine.graphics.graphics_batch.glPushAttrib')
+    @patch('engine.graphics.graphics_batch.glPopAttrib')
+    @patch('engine.graphics.graphics_batch.glEnable')
+    @patch('engine.graphics.graphics_batch.glLineStipple')
+    def test_draw_dashed_lines(self, mock_line_stipple, mock_enable, mock_pop,
+                               mock_push):
+        """Graphics batches can be drawn with dashed lines."""
+        batch = GraphicsBatch()
+        batch.draw = Mock()
+        batch.draw_special(GraphicsBatch.DASHED_LINES)
+
+        mock_push.assert_called_once_with(GL_ENABLE_BIT)
+        mock_line_stipple.assert_called_once_with(1, 0x00FF)
+        mock_enable.assert_called_once_with(GL_LINE_STIPPLE)
+        batch.draw.assert_called_once_with()
+        mock_pop.assert_called_once_with()

--- a/engine/world/__init__.py
+++ b/engine/world/__init__.py
@@ -1,3 +1,4 @@
 from .world_2d import World2d
+from .world_2d_debug import World2dDebug
 
-__all__ = ['World2d']
+__all__ = ['World2d', 'World2dDebug']

--- a/engine/world/tests/test_world_2d_debug.py
+++ b/engine/world/tests/test_world_2d_debug.py
@@ -1,0 +1,167 @@
+from ..world_2d_debug import World2dDebug
+from ..world_object import WorldObject, COLLIDER, TRIGGER
+from unittest.mock import call, Mock, patch, ANY
+import unittest
+
+
+class TestWorld2dDebug(unittest.TestCase):
+    """Test functionality of the ``World2dDebug`` class."""
+
+    def setUp(self):
+        """Creates the following for each test:
+
+        * ``self.collider``: Object for a collider.
+        * ``self.trigger``: Object for a trigger.
+        * ``self.world``: World with the collider and trigger, in that order.
+        """
+        self.collider = Mock()
+        self.trigger = Mock()
+        self.world = Mock(_objects=[
+            WorldObject(self.collider, COLLIDER),
+            WorldObject(self.trigger, TRIGGER)])
+
+    @patch('engine.world.world_2d_debug.CrossBox')
+    @patch('engine.world.world_2d_debug.GraphicsBatch')
+    def test_existing_objects_create_shapes(self, MockBatch, MockBox):
+        """Existing objects in the world have debug shapes created for them."""
+        World2dDebug(self.world)
+
+        MockBox.assert_has_calls([
+            call(self.collider, ANY, ANY),
+            call(self.trigger, ANY, ANY)])
+
+    @patch('engine.world.world_2d_debug.CrossBox')
+    @patch('engine.world.world_2d_debug.GraphicsBatch')
+    def test_existing_objects_use_color_for_type(self, MockBatch, MockBox):
+        """Existing objects use the given color for their type."""
+        World2dDebug(
+            self.world, collider_color=(1, 2, 3), trigger_color=(4, 5, 6))
+
+        MockBox.assert_has_calls([
+            call(self.collider, (1, 2, 3), ANY),
+            call(self.trigger, (4, 5, 6), ANY)])
+
+    @patch('engine.world.world_2d_debug.CrossBox')
+    @patch('engine.world.world_2d_debug.GraphicsBatch')
+    def test_existing_objects_are_batched_by_type(self, MockBatch, MockBox):
+        """Existing objects are added to the graphics batch for their type."""
+        batch_1, batch_2 = Mock(), Mock()
+        MockBatch.side_effect = [batch_1, batch_2]
+
+        World2dDebug(self.world)
+
+        collider_batch = MockBox.mock_calls[0].args[2]
+        trigger_batch = MockBox.mock_calls[1].args[2]
+
+        self.assertNotEqual(trigger_batch, collider_batch)
+        self.assertIn(collider_batch, (batch_1, batch_2))
+        self.assertIn(trigger_batch, (batch_1, batch_2))
+
+    @patch('engine.world.world_2d_debug.CrossBox')
+    @patch('engine.world.world_2d_debug.GraphicsBatch')
+    def test_new_triggers_added_to_trigger_batch(self, MockBatch, MockBox):
+        """New triggers are added to the trigger graphics batch."""
+        mock_trigger = Mock()
+        batch_1, batch_2 = Mock(), Mock()
+        MockBatch.side_effect = [batch_1, batch_2]
+
+        World2dDebug(self.world)
+
+        # Get the registered on_trigger_add listener
+        trigger_listener = list(filter(
+            lambda call: 'on_trigger_add' in call.kwargs,
+            self.world.add_listeners.mock_calls
+        ))[0].kwargs['on_trigger_add']
+
+        # Call the listener that fires when on_trigger_add occurs
+        trigger_listener(mock_trigger)
+
+        trigger_batch = MockBox.mock_calls[1].args[2]
+
+        MockBox.assert_any_call(mock_trigger, ANY, trigger_batch)
+
+    @patch('engine.world.world_2d_debug.CrossBox')
+    @patch('engine.world.world_2d_debug.GraphicsBatch')
+    def test_new_colliders_added_to_collider_batch(self, MockBatch, MockBox):
+        """New colliders are added to the collider graphics batch."""
+        mock_collider = Mock()
+        batch_1, batch_2 = Mock(), Mock()
+        MockBatch.side_effect = [batch_1, batch_2]
+
+        World2dDebug(self.world)
+
+        # Get the registered on_collider_add listener
+        collider_listener = list(filter(
+            lambda call: 'on_collider_add' in call.kwargs,
+            self.world.add_listeners.mock_calls
+        ))[0].kwargs['on_collider_add']
+
+        # Call the listener that fires when on_collider_add occurs
+        collider_listener(mock_collider)
+
+        collider_batch = MockBox.mock_calls[0].args[2]
+
+        MockBox.assert_any_call(mock_collider, ANY, collider_batch)
+
+    @patch('engine.world.world_2d_debug.CrossBox')
+    @patch('engine.world.world_2d_debug.GraphicsBatch')
+    def test_updates_objects_after_world_update(self, MockBatch, MockBox):
+        """The world debugger updates when the world has finished updating."""
+        mock_collider, mock_trigger = Mock(), Mock()
+
+        World2dDebug(self.world)
+
+        trigger_listener = list(filter(
+            lambda call: 'on_trigger_add' in call.kwargs,
+            self.world.add_listeners.mock_calls
+        ))[0].kwargs['on_trigger_add']
+
+        collider_listener = list(filter(
+            lambda call: 'on_collider_add' in call.kwargs,
+            self.world.add_listeners.mock_calls
+        ))[0].kwargs['on_collider_add']
+
+        update_listener = list(filter(
+            lambda call: 'on_update_exit' in call.kwargs,
+            self.world.add_listeners.mock_calls
+        ))[0].kwargs['on_update_exit']
+
+        trigger_listener(mock_trigger)
+        collider_listener(mock_collider)
+
+        # Call the listener that fires when on_update_exit occurs
+        update_listener(self.world)
+
+        MockBox.return_value.set_position.assert_has_calls([
+            call(self.collider.coordinates),
+            call(mock_collider.coordinates),
+            call(self.trigger.coordinates),
+            call(mock_trigger.coordinates),
+        ], any_order=True)
+
+    @patch('engine.world.world_2d_debug.CrossBox')
+    @patch('engine.world.world_2d_debug.GraphicsBatch')
+    def test_collider_batch_is_drawn_normally(self, MockBatch, MockBox):
+        """The collider batch is drawn normally during a debug draw."""
+        batch_1, batch_2 = Mock(), Mock()
+        MockBatch.side_effect = [batch_1, batch_2]
+
+        world_debug = World2dDebug(self.world)
+        world_debug.draw()
+
+        collider_batch = MockBox.mock_calls[0].args[2]
+        collider_batch.draw.assert_called_once_with()
+
+    @patch('engine.world.world_2d_debug.CrossBox')
+    @patch('engine.world.world_2d_debug.GraphicsBatch')
+    def test_trigger_batch_is_drawn_with_dashed_line(self, MockBatch, MockBox):
+        """The trigger batch is drawn with dashed lines during a debug draw."""
+        batch_1, batch_2 = Mock(), Mock()
+        MockBatch.side_effect = [batch_1, batch_2]
+
+        world_debug = World2dDebug(self.world)
+        world_debug.draw()
+
+        trigger_batch = MockBox.mock_calls[1].args[2]
+        trigger_batch.draw_special.assert_called_once_with(
+            MockBatch.DASHED_LINES)

--- a/engine/world/world_2d_debug.py
+++ b/engine/world/world_2d_debug.py
@@ -1,0 +1,65 @@
+from engine.graphics import CrossBox, GraphicsBatch
+from .world_object import TRIGGER
+
+
+class World2dDebug(object):
+    """Debug properties for a :obj:`world_2d.World2d` instance."""
+
+    def __init__(self, world, collider_color=(0, 255, 128),
+                 trigger_color=(0, 255, 255)):
+        """Creates a new visual debugger for a :obj:`world_2d.World2d`.
+
+        Args:
+            world (list of :obj:`world_2d.World2d`):
+                The world to render debug shapes for.
+
+        Kwargs:
+            collider_color (tuple of 3 int):
+                RGB color tuple to draw colliders with. Default is green.
+            trigger_color (tuple of 3 int):
+                RGB color tuple to draw triggers with. Default is cyan.
+        """
+        super(World2dDebug, self).__init__()
+        self._collider_batch = GraphicsBatch()
+        self._collider_color = collider_color
+
+        self._trigger_batch = GraphicsBatch()
+        self._trigger_color = trigger_color
+
+        self._debug_objects = {}
+
+        # Create debug shapes for all objects in the world
+        for obj in world._objects:
+            if obj.type == TRIGGER:
+                self._add_trigger(obj.object)
+            else:
+                self._add_collider(obj.object)
+
+        # Update our debug shapes when the world is updated
+        world.add_listeners(on_update_exit=self._update)
+
+        # Create debug shapes for colliders and triggers as they're added
+        world.add_listeners(on_collider_add=self._add_collider)
+        world.add_listeners(on_trigger_add=self._add_trigger)
+
+    def draw(self):
+        """Draws a solid cross box for colliders and dashed for triggers."""
+        self._collider_batch.draw()
+        self._trigger_batch.draw_special(GraphicsBatch.DASHED_LINES)
+
+    def _update(self, world):
+        """Update debug shapes to match their corresponding world objects."""
+        for obj, debug_shape in self._debug_objects.items():
+            debug_shape.set_position(obj.coordinates)
+
+    def _add_collider(self, collider):
+        """Adds a collider to this debug instance."""
+        self._add_object(collider, self._collider_color, self._collider_batch)
+
+    def _add_trigger(self, trigger):
+        """Adds a trigger to this debug instance."""
+        self._add_object(trigger, self._trigger_color, self._trigger_batch)
+
+    def _add_object(self, obj, color, batch):
+        """Adds an object to this debug instance."""
+        self._debug_objects[obj] = CrossBox(obj, color, batch)

--- a/pickles-fetch-quest.py
+++ b/pickles-fetch-quest.py
@@ -16,7 +16,8 @@ graphics_director = graphics.GraphicsController(
     game_width * game_scale, game_height * game_scale,
     title="Pickle's Fetch Quest")
 key_handler = key_handler.KeyHandler(graphics_director)
-world = world.World2d()
+game_world = world.World2d()
+game_world_debugger = world.World2dDebug(game_world)
 
 audio_director.attenuation_distance = 40
 
@@ -26,7 +27,7 @@ collision_sound = audio_director.load(
 (pickle, pickle_graphics) = player.create_player(key_handler)
 
 graphics_director.add_listeners(on_update=pickle.update)
-world.add_collider(pickle)
+game_world.add_collider(pickle)
 
 
 def create_floor_physics(**kwargs):
@@ -42,7 +43,7 @@ def create_floor_physics(**kwargs):
 
     tile.add_listeners(on_collider_enter=play_collision_audio)
     graphics_director.add_listeners(on_update=tile.update)
-    world.add_collider(tile)
+    game_world.add_collider(tile)
 
     return tile
 
@@ -74,7 +75,7 @@ camera.follow_easing = easing.LinearInterpolation(0.08)
 
 
 def on_update(dt):
-    world.update(dt)
+    game_world.update(dt)
     key_handler.update(dt)
     entry_room.update(dt)
     camera.update(dt)
@@ -82,12 +83,12 @@ def on_update(dt):
 
 graphics_director.add_listeners(on_update=on_update)
 
-
 @graphics_director._window.event
 def on_draw():
     graphics_director._window.clear()
     camera.attach()
     entry_room.draw()
+    game_world_debugger.draw()
     camera.detach()
 
 


### PR DESCRIPTION
A small smattering of primitive OpenGL graphics, events for the 2d world representation, and a "world debugger" which is given a world and renders objects both existing and newly added. Colliders are drawn in green with a solid line, while triggers are cyan with dashed lines.

![pickle-debug](https://user-images.githubusercontent.com/2885412/92317435-67ee2200-efb5-11ea-8b94-430b1554da3f.gif)
